### PR TITLE
retry if we fail to download apt-keys from Ubuntu's keyserver

### DIFF
--- a/tasks/webupd8_for_debian.yml
+++ b/tasks/webupd8_for_debian.yml
@@ -2,6 +2,10 @@
 
 - name: Install WebUpd8 apt key
   apt_key: id=EEA14886 keyserver='keyserver.ubuntu.com' state=present
+  register: webupd8key
+  until: webupd8key|success
+  retries: 5
+  delay: 10
 
 - name: Install WebUpd8 Team Java PPA (for Oracle Java)
   apt_repository: repo='deb http://ppa.launchpad.net/webupd8team/java/ubuntu precise main' state=present

--- a/tasks/webupd8_for_ubuntu.yml
+++ b/tasks/webupd8_for_ubuntu.yml
@@ -2,6 +2,10 @@
 - name: Install WebUpd8 Team Java PPA (for Oracle Java)
   apt_repository: repo='ppa:webupd8team/java' state=present
   when: java_needs_oracle
+  register: webupd8ppa
+  until: webupd8ppa|success
+  retries: 5
+  delay: 10
 
 - name: Remove WebUpd8 Team Java PPA (for Oracle Java)
   apt_repository: repo='ppa:webupd8team/java' state=present


### PR DESCRIPTION
Ubuntu's keyserver (`keyserver.ubuntu.com`) sometimes doesn't respond, failing the ansible run. This PR will retry requests to the keyserver on failure. In reponse to https://github.com/smola/ansible-java-role/issues/14
