### PR TITLE
Using bare variables is deprecated in Ansible 2.x. 

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -21,9 +21,9 @@
 
 - name: Install Java packages
   apt: pkg={{ item }} state=latest
-  with_items: java_packages
+  with_items: "{{ java_packages }}"
 
 - name: Remove unwanted Java packages
   apt: pkg={{ item }} state=absent
-  with_items: java_packages_to_remove
+  with_items: "{{ java_packages_to_remove }}"
   when: java_cleanup


### PR DESCRIPTION
Updating to use the full variable syntax and eliminate deprecation warnings from ansible.
