### PR TITLE
change instances of "with_items" to ansible 2.2 notation

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -21,9 +21,9 @@
 
 - name: Install Java packages
   apt: pkg={{ item }} state=latest
-  with_items: java_packages
+  with_items:  "{{ java_packages }}"
 
 - name: Remove unwanted Java packages
   apt: pkg={{ item }} state=absent
-  with_items: java_packages_to_remove
+  with_items: "{{ java_packages_to_remove }}"
   when: java_cleanup

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 
 - name: Install Java packages
   yum: name={{ item }} state=latest
-  with_items: java_packages
+  with_items:  "{{ java_packages }}"
   when: ansible_os_family == 'RedHat'
 
 


### PR DESCRIPTION
The "with_items" usage changed in ansible 2.2, see [latest documentation](http://docs.ansible.com/ansible/playbooks_loops.html#standard-loop), and note [the commit where the ansible documentation was updated](https://github.com/ansible/ansible/commit/c7e1a65da4ff06ead2202dcb3eea30787566ca86)

~~Not sure if this will break things for ansible versions before 2.2, I haven't tested that.~~
Note that the CI test is using 1.6.3, and failing.